### PR TITLE
記事一覧機能の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::ArticlesController < Api::V1::BaseApiController
+  def index
+    articles = Article.order(updated_at: :desc)
+    render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+  end
+end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -19,8 +19,8 @@
 #
 FactoryBot.define do
   factory :article do
-    title { "MyString" }
-    body { "MyText" }
+    title { Faker::Lorem.word }
+    body { Faker::Lorem.sentence }
     user
   end
 end

--- a/spec/requests/api/v1/article_spec.rb
+++ b/spec/requests/api/v1/article_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /index" do
+    subject { get(api_v1_articles_path) }
+
+    let!(:article1) { create(:article, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article) }
+    it "記事の一覧が取得できる", :aggregate_failures do
+      subject
+      res = JSON.parse(response.body)
+      # HTTPステータスコードが200である
+      expect(response).to have_http_status(:ok)
+      # 記事の個数は一致しているか
+      expect(res.count).to eq 3
+      # 返ってきた記事は、リクエスト通りか => それぞれのカラムを比較
+      expect(res.map {|n| n["id"] }).to eq [article3.id, article1.id, article2.id]
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      # 関連するuserもリクエスト通りのカラムか
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- serializer を使ってjsonを返すようにする
- `bundle exec rails g serializer api::v1::articlepreview`
- articles_controller でserializer を使うようにする
- `bundle exec rails g controller api::v1::article`
- request spec を使ったテストの実装